### PR TITLE
Enable SQL seeding for product table

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     enabled: false
   sql:
     init:
-      mode: never
+      mode: always
 
 logging:
   level:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,2 +1,2 @@
-INSERT INTO products (id, name, price) VALUES (UUID_TO_BIN(UUID()), 'Laptop', 1200.00);
-INSERT INTO products (id, name, price) VALUES (UUID_TO_BIN(UUID()), 'Phone', 800.00);
+INSERT INTO product (id, name, price) VALUES (UUID_TO_BIN(UUID()), 'Laptop', 1200.00);
+INSERT INTO product (id, name, price) VALUES (UUID_TO_BIN(UUID()), 'Phone', 800.00);


### PR DESCRIPTION
## Summary
- Seed H2 database using `product` table instead of `products`
- Always run SQL initialization scripts on startup

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b5c6c2d08320a958329c37ce3c89