### PR TITLE
Set root logging level to INFO

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
 
 logging:
   level:
-    root: DEBUG
+    root: INFO
 
 # Note:
 # - Default profile uses in-memory H2 so the app runs without external DB.


### PR DESCRIPTION
## Summary
- use INFO for root logging level

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b7499b808320a6fa682fe1ceabd8