### PR TITLE
Add positive price validation to ProductRequest

### DIFF
--- a/src/main/java/com/dalu/productapp/interfaces/product/dto/ProductRequest.java
+++ b/src/main/java/com/dalu/productapp/interfaces/product/dto/ProductRequest.java
@@ -2,6 +2,7 @@ package com.dalu.productapp.interfaces.product.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -12,6 +13,7 @@ public class ProductRequest {
     private String name;
 
     @NotNull(message = "Price is required")
+    @Positive(message = "Price must be positive")
     private BigDecimal price;
 
     public ProductRequest() {


### PR DESCRIPTION
## Summary
- require ProductRequest price to be positive

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b86a798083209bd5c03e5d6a0aef