### PR TITLE
Accept BigDecimal price for update endpoint

### DIFF
--- a/src/main/java/com/dalu/productapp/interfaces/product/ProductController.java
+++ b/src/main/java/com/dalu/productapp/interfaces/product/ProductController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -39,8 +40,8 @@ public class ProductController {
 
     @PutMapping("/{id}/price")
     public ResponseEntity<ApiResponse<ProductResponse>> updatePrice(@PathVariable UUID id,
-                                                       @RequestParam double price) {
-        Product updated = service.updatePrice(id, java.math.BigDecimal.valueOf(price));
+                                                       @RequestParam BigDecimal price) {
+        Product updated = service.updatePrice(id, price);
         ProductResponse response = new ProductResponse(updated.getId(), updated.getName(), updated.getPrice());
         return ResponseEntity.ok(ApiResponse.success(response, "Price updated successfully"));
     }


### PR DESCRIPTION
## Summary
- Accept price as `BigDecimal` in `ProductController.updatePrice`
- Pass the `BigDecimal` directly to the service for price updates

## Testing
- `./mvnw -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b8cefa0883208578d0750c96f2b7