### PR TITLE
Add error response with data and enhance validation handler

### DIFF
--- a/src/main/java/com/dalu/productapp/interfaces/GlobalExceptionHandler.java
+++ b/src/main/java/com/dalu/productapp/interfaces/GlobalExceptionHandler.java
@@ -23,7 +23,8 @@ public class GlobalExceptionHandler {
             String errorMessage = error.getDefaultMessage();
             errors.put(fieldName, errorMessage);
         });
-        return ResponseEntity.badRequest().body(ApiResponse.error(errors.toString()));
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error(errors, "Validation failed"));
     }
 
     @ExceptionHandler(ProductNotFoundException.class)

--- a/src/main/java/com/dalu/productapp/interfaces/common/ApiResponse.java
+++ b/src/main/java/com/dalu/productapp/interfaces/common/ApiResponse.java
@@ -12,6 +12,10 @@ public record ApiResponse<T>(
         return new ApiResponse<>("success", data, message, Instant.now());
     }
 
+    public static <T> ApiResponse<T> error(T data, String message) {
+        return new ApiResponse<>("error", data, message, Instant.now());
+    }
+
     public static <T> ApiResponse<T> error(String message) {
         return new ApiResponse<>("error", null, message, Instant.now());
     }


### PR DESCRIPTION
## Summary
- Add `error(T data, String message)` to `ApiResponse` for structured error payloads
- Return data and message in validation exception handler via new `ApiResponse.error`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b94ddab88320bbd3d6dfd3a3814c