### PR TITLE
Add OpenAPI configuration and document Swagger UI access

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 
 ## API Documentation
 
-- Swagger UI: `http://localhost:8080/swagger-ui.html`  
-- OpenAPI spec: `http://localhost:8080/v3/api-docs`  
+After starting the application, open `http://localhost:8080/swagger-ui.html` in your browser to view the interactive Swagger UI. The generated OpenAPI specification is available at `http://localhost:8080/v3/api-docs`.
 
 ---
 

--- a/src/main/java/com/dalu/productapp/config/OpenApiConfig.java
+++ b/src/main/java/com/dalu/productapp/config/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package com.dalu.productapp.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI productApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Product API")
+                        .description("API documentation for ProductApp")
+                        .version("v1"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,7 @@ logging:
 # Note:
 # - Default profile uses in-memory H2 so the app runs without external DB.
 # - For MySQL, use: -Dspring.profiles.active=dev and ensure MySQL is running.
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
## Summary
- add OpenAPI configuration bean with API title, description, and version
- expose Swagger UI at `/swagger-ui.html`
- document how to reach the Swagger UI

## Testing
- `./mvnw -q package` *(fails: Network is unreachable)*
- `./mvnw -q spring-boot:run` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bee032d0832083da6e4ddcb6b831